### PR TITLE
Update dev container for test dependencies

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,6 +3,10 @@
     "build": {
         "dockerfile": "../Dockerfile"
     },
+    "remoteEnv": {
+        "DISPLAY": "host.docker.internal:0",
+        "LADSPA_PATH": "../build/src"
+    },
     "customizations": {
         "vscode": {
             "extensions": [

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,10 @@ FROM ubuntu:latest
 
 RUN apt-get update
 RUN apt-get install -y build-essential -y cmake
-RUN apt-get install -y ladspa-sdk
+RUN apt-get install -y ladspa-sdk ecasound sox libfftw3-dev
+RUN apt-get install -y r-base
+
+# Install R packages
+RUN R -e "install.packages('tuneR', repos='http://cran.rstudio.com/')"
+RUN R -e "install.packages('sound', repos='http://cran.rstudio.com/')"
+RUN R -e "install.packages('fftw', repos='http://cran.rstudio.com/')"


### PR DESCRIPTION
Now it's possible to run the R test scripts directly from within the dev container.

- Start XQuartz on macOS
- From within dev container terminal in the `testing` directory:
    - Run `R CMD SHLIB mls.c` to build shared MLS library
    - Run `Rscript ladspa_testing.R` to test filters and plot frequency response

Resolves #3 