### PR TITLE
Implement RTlinkwitzeq plugin

### DIFF
--- a/include/linkwitz.h
+++ b/include/linkwitz.h
@@ -1,0 +1,44 @@
+#ifndef LINKWITZ_H
+#define LINKWITZ_H
+
+#include <math.h>
+
+#ifndef BIQUAD_TYPE
+#define BIQUAD_TYPE double
+#endif
+
+typedef BIQUAD_TYPE bq_t;
+
+/* Linkwitz transform biquad calculator
+   Calculates coefficients for a Linkwitz transform that converts
+   a speaker with f0/Q0 to a target response of fp/Qp */
+static inline void calculate_linkwitz_biquad(
+        bq_t *a, bq_t *b,
+        bq_t f0, bq_t q0,
+        bq_t fp, bq_t qp,
+        bq_t fs) {
+
+    // Analog domain coefficients
+    bq_t d0i = pow((2*M_PI*f0), 2);
+    bq_t d1i = (2*M_PI*f0)/q0;
+    bq_t d2i = 1;
+
+    bq_t c0i = pow((2*M_PI*fp), 2);
+    bq_t c1i = (2*M_PI*fp)/qp;
+    bq_t c2i = 1;
+
+    bq_t fc = (f0 + fp) / 2;
+    bq_t gn = (2*M_PI*fc)/(tan(M_PI*fc/fs));
+    bq_t cci = c0i+gn*c1i+gn*gn*c2i;
+
+    // Digital domain coefficients
+    a[0] = 1;
+    a[1] = (2*(c0i-(gn*gn)*c2i)/cci);
+    a[2] = ((c0i-gn*c1i+(gn*gn)*c2i)/cci);
+
+    b[0] = (d0i+gn*d1i+(gn*gn)*d2i)/cci;
+    b[1] = 2*(d0i-(gn*gn)*d2i)/cci;
+    b[2] = (d0i-gn*d1i+(gn*gn)*d2i)/cci;
+}
+
+#endif // LINKWITZ_H 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,12 +21,14 @@ add_library(RThighpass1 MODULE RThighpass1.c)
 
 add_library(RTdecorrmls MODULE RTdecorrmls.c)
 
-set_target_properties(RTallpass1 RTallpass2 RTlowpass RThighpass RTlowshelf RThighshelf RTlr4hipass RTlr4lowpass RTparaeq RTlowpass1 RThighpass1 RTdecorrmls
+add_library(RTlinkwitzeq MODULE RTlinkwitzeq.c)
+
+set_target_properties(RTallpass1 RTallpass2 RTlowpass RThighpass RTlowshelf RThighshelf RTlr4hipass RTlr4lowpass RTparaeq RTlowpass1 RThighpass1 RTdecorrmls RTlinkwitzeq
                       PROPERTIES LINK_FLAGS "-nostartfiles")
 if(USE_SSE2)
-  set_target_properties(RTallpass1 RTallpass2 RTlowpass RThighpass RTlowshelf RThighshelf RTlr4hipass RTlr4lowpass RTparaeq RTlowpass1 RThighpass1 RTdecorrmls
+  set_target_properties(RTallpass1 RTallpass2 RTlowpass RThighpass RTlowshelf RThighshelf RTlr4hipass RTlr4lowpass RTparaeq RTlowpass1 RThighpass1 RTdecorrmls RTlinkwitzeq
                         PROPERTIES COMPILE_FLAGS "-msse2 -mfpmath=sse")
 endif()
-install(TARGETS RTallpass1 RTallpass2 RTlowpass RThighpass RTlowshelf RThighshelf RTlr4hipass RTlr4lowpass RTparaeq RTlowpass1 RThighpass1 RTdecorrmls
+install(TARGETS RTallpass1 RTallpass2 RTlowpass RThighpass RTlowshelf RThighshelf RTlr4hipass RTlr4lowpass RTparaeq RTlowpass1 RThighpass1 RTdecorrmls RTlinkwitzeq
         LIBRARY DESTINATION lib/ladspa)
 

--- a/src/RTlinkwitzeq.c
+++ b/src/RTlinkwitzeq.c
@@ -1,0 +1,141 @@
+#include <stdlib.h>
+#include <string.h>
+#include <ladspa.h>
+
+#define LINKWITZ_F0 0
+#define LINKWITZ_Q0 1
+#define LINKWITZ_FP 2
+#define LINKWITZ_QP 3
+
+static LADSPA_Descriptor *linkwitzDescriptor = NULL;
+
+typedef struct {
+    LADSPA_Data *f0;
+    LADSPA_Data *q0;
+    LADSPA_Data *fp;
+    LADSPA_Data *qp;
+} Linkwitz;
+
+const LADSPA_Descriptor *ladspa_descriptor(unsigned long index) {
+    switch (index) {
+    case 0:
+        return linkwitzDescriptor;
+    default:
+        return NULL;
+    }
+}
+
+static void activateLinkwitz(LADSPA_Handle instance) {
+    // Activation code here
+}
+
+static void cleanupLinkwitz(LADSPA_Handle instance) {
+    free(instance);
+}
+
+static void connectPortLinkwitz(
+    LADSPA_Handle instance,
+    unsigned long port,
+    LADSPA_Data *data) {
+    Linkwitz *plugin = (Linkwitz *)instance;
+    switch (port) {
+    case LINKWITZ_F0:
+        plugin->f0 = data;
+        break;
+    case LINKWITZ_Q0:
+        plugin->q0 = data;
+        break;
+    case LINKWITZ_FP:
+        plugin->fp = data;
+        break;
+    case LINKWITZ_QP:
+        plugin->qp = data;
+        break;
+    }
+}
+
+static LADSPA_Handle instantiateLinkwitz(
+    const LADSPA_Descriptor *descriptor,
+    unsigned long s_rate) {
+    Linkwitz *plugin_data = (Linkwitz *)malloc(sizeof(Linkwitz));
+    return (LADSPA_Handle)plugin_data;
+}
+
+static void runLinkwitz(LADSPA_Handle instance, unsigned long sample_count) {
+    // Signal processing code here
+}
+
+void _init(void);
+void _init(void) {
+    char **port_names;
+    LADSPA_PortDescriptor *port_descriptors;
+    LADSPA_PortRangeHint *port_range_hints;
+
+    linkwitzDescriptor = (LADSPA_Descriptor *)malloc(sizeof(LADSPA_Descriptor));
+
+    if (linkwitzDescriptor) {
+        linkwitzDescriptor->UniqueID = 9003;
+        linkwitzDescriptor->Label = "RTlinkwitzeq";
+        linkwitzDescriptor->Properties = LADSPA_PROPERTY_HARD_RT_CAPABLE;
+        linkwitzDescriptor->Name = "RT Linkwitz Equalizer";
+        linkwitzDescriptor->Maker = "Stefan Janhunen <sjanhunen@gmail.com>";
+        linkwitzDescriptor->Copyright = "GPL";
+        linkwitzDescriptor->PortCount = 4;
+
+        port_descriptors = (LADSPA_PortDescriptor *)calloc(4, sizeof(LADSPA_PortDescriptor));
+        linkwitzDescriptor->PortDescriptors = (const LADSPA_PortDescriptor *)port_descriptors;
+
+        port_range_hints = (LADSPA_PortRangeHint *)calloc(4, sizeof(LADSPA_PortRangeHint));
+        linkwitzDescriptor->PortRangeHints = (const LADSPA_PortRangeHint *)port_range_hints;
+
+        port_names = (char **)calloc(4, sizeof(char*));
+        linkwitzDescriptor->PortNames = (const char **)port_names;
+
+        // Parameters for f0
+        port_descriptors[LINKWITZ_F0] = LADSPA_PORT_INPUT | LADSPA_PORT_CONTROL;
+        port_names[LINKWITZ_F0] = "f0 - Natural resonant frequency of the driver in a sealed box";
+        port_range_hints[LINKWITZ_F0].HintDescriptor = LADSPA_HINT_BOUNDED_BELOW | LADSPA_HINT_BOUNDED_ABOVE;
+        port_range_hints[LINKWITZ_F0].LowerBound = 0.0F;
+        port_range_hints[LINKWITZ_F0].UpperBound = 20000.0F;
+
+        // Parameters for Q0
+        port_descriptors[LINKWITZ_Q0] = LADSPA_PORT_INPUT | LADSPA_PORT_CONTROL;
+        port_names[LINKWITZ_Q0] = "Q0 - Natural Q factor of the driver in a sealed box";
+        port_range_hints[LINKWITZ_Q0].HintDescriptor = LADSPA_HINT_BOUNDED_BELOW | LADSPA_HINT_BOUNDED_ABOVE;
+        port_range_hints[LINKWITZ_Q0].LowerBound = 0.1F;
+        port_range_hints[LINKWITZ_Q0].UpperBound = 10.0F;
+
+        // Parameters for fp
+        port_descriptors[LINKWITZ_FP] = LADSPA_PORT_INPUT | LADSPA_PORT_CONTROL;
+        port_names[LINKWITZ_FP] = "fp - Equalized resonant frequency of the driver in a sealed box";
+        port_range_hints[LINKWITZ_FP].HintDescriptor = LADSPA_HINT_BOUNDED_BELOW | LADSPA_HINT_BOUNDED_ABOVE;
+        port_range_hints[LINKWITZ_FP].LowerBound = 0.0F;
+        port_range_hints[LINKWITZ_FP].UpperBound = 20000.0F;
+
+        // Parameters for Qp
+        port_descriptors[LINKWITZ_QP] = LADSPA_PORT_INPUT | LADSPA_PORT_CONTROL;
+        port_names[LINKWITZ_QP] = "Qp - Equalized Q factor of the driver in a sealed box";
+        port_range_hints[LINKWITZ_QP].HintDescriptor = LADSPA_HINT_BOUNDED_BELOW | LADSPA_HINT_BOUNDED_ABOVE;
+        port_range_hints[LINKWITZ_QP].LowerBound = 0.1F;
+        port_range_hints[LINKWITZ_QP].UpperBound = 10.0F;
+
+        linkwitzDescriptor->activate = activateLinkwitz;
+        linkwitzDescriptor->cleanup = cleanupLinkwitz;
+        linkwitzDescriptor->connect_port = connectPortLinkwitz;
+        linkwitzDescriptor->deactivate = NULL;
+        linkwitzDescriptor->instantiate = instantiateLinkwitz;
+        linkwitzDescriptor->run = runLinkwitz;
+        linkwitzDescriptor->run_adding = NULL;
+        linkwitzDescriptor->set_run_adding_gain = NULL;
+    }
+}
+
+void _fini(void);
+void _fini(void) {
+    if (linkwitzDescriptor) {
+        free((LADSPA_PortDescriptor *)linkwitzDescriptor->PortDescriptors);
+        free((char **)linkwitzDescriptor->PortNames);
+        free((LADSPA_PortRangeHint *)linkwitzDescriptor->PortRangeHints);
+        free(linkwitzDescriptor);
+    }
+}

--- a/src/RTlinkwitzeq.c
+++ b/src/RTlinkwitzeq.c
@@ -1,11 +1,16 @@
 #include <stdlib.h>
 #include <string.h>
+#include <stdio.h>
 #include <ladspa.h>
+#include "biquad.h"
+#include "linkwitz.h"
 
 #define LINKWITZ_F0 0
 #define LINKWITZ_Q0 1
 #define LINKWITZ_FP 2
 #define LINKWITZ_QP 3
+#define LINKWITZ_INPUT 4
+#define LINKWITZ_OUTPUT 5
 
 static LADSPA_Descriptor *linkwitzDescriptor = NULL;
 
@@ -14,6 +19,10 @@ typedef struct {
     LADSPA_Data *q0;
     LADSPA_Data *fp;
     LADSPA_Data *qp;
+    LADSPA_Data *input;
+    LADSPA_Data *output;
+    biquad *filter;
+    float fs;
 } Linkwitz;
 
 const LADSPA_Descriptor *ladspa_descriptor(unsigned long index) {
@@ -26,10 +35,17 @@ const LADSPA_Descriptor *ladspa_descriptor(unsigned long index) {
 }
 
 static void activateLinkwitz(LADSPA_Handle instance) {
-    // Activation code here
+    Linkwitz *plugin_data = (Linkwitz *)instance;
+    biquad *filter = plugin_data->filter;
+    float fs = plugin_data->fs;
+    biquad_init(filter);
+    plugin_data->filter = filter;
+    plugin_data->fs = fs;
 }
 
 static void cleanupLinkwitz(LADSPA_Handle instance) {
+    Linkwitz *plugin_data = (Linkwitz *)instance;
+    free(plugin_data->filter);
     free(instance);
 }
 
@@ -51,6 +67,12 @@ static void connectPortLinkwitz(
     case LINKWITZ_QP:
         plugin->qp = data;
         break;
+    case LINKWITZ_INPUT:
+        plugin->input = data;
+        break;
+    case LINKWITZ_OUTPUT:
+        plugin->output = data;
+        break;
     }
 }
 
@@ -58,11 +80,70 @@ static LADSPA_Handle instantiateLinkwitz(
     const LADSPA_Descriptor *descriptor,
     unsigned long s_rate) {
     Linkwitz *plugin_data = (Linkwitz *)malloc(sizeof(Linkwitz));
+    biquad *filter = NULL;
+    float fs;
+
+    fs = (float)s_rate;
+    filter = malloc(sizeof(biquad));
+    biquad_init(filter);
+
+    plugin_data->filter = filter;
+    plugin_data->fs = fs;
+
     return (LADSPA_Handle)plugin_data;
 }
 
+#undef buffer_write
+#define buffer_write(b, v) (b = v)
+
 static void runLinkwitz(LADSPA_Handle instance, unsigned long sample_count) {
-    // Signal processing code here
+    Linkwitz *plugin_data = (Linkwitz *)instance;
+
+    /* Natural resonant frequency (Hz) */
+    const LADSPA_Data f0 = *(plugin_data->f0);
+
+    /* Natural Q factor */
+    const LADSPA_Data q0 = *(plugin_data->q0);
+
+    /* Target resonant frequency (Hz) */
+    const LADSPA_Data fp = *(plugin_data->fp);
+
+    /* Target Q factor */
+    const LADSPA_Data qp = *(plugin_data->qp);
+
+    /* Input (array of floats of length sample_count) */
+    const LADSPA_Data * const input = plugin_data->input;
+
+    /* Output (array of floats of length sample_count) */
+    LADSPA_Data * const output = plugin_data->output;
+    biquad * filter = plugin_data->filter;
+    float fs = plugin_data->fs;
+
+    unsigned long pos;
+    bq_t a[3], b[3];
+
+    calculate_linkwitz_biquad(a, b, f0, q0, fp, qp, fs);
+
+    /*
+     * biquad_run() is written for the difference equation
+     *   y[n] = b0 x[n] + b1 x[n-1] + b2 x[n-2]
+     *          + a1 y[n-1] + a2 y[n-2]
+     * which corresponds to the transfer function
+     *   H(z) = (b0 + b1 z^-1 + b2 z^-2) / (1 - a1 z^-1 - a2 z^-2)
+     * Note the minus-signs in the denominator.  The coefficients
+     * returned by calculate_linkwitz_biquad() are in the more common
+     * "DSP textbook" form 1 + a1 z^-1 + a2 z^-2.  Therefore we need
+     * to negate a1 and a2 before feeding them to the runtime filter.
+     */
+    filter->a1 = -a[1];
+    filter->a2 = -a[2];
+    filter->b0 = b[0];
+    filter->b1 = b[1];
+    filter->b2 = b[2];
+
+    for (pos = 0; pos < sample_count; pos++) {
+        buffer_write(output[pos], (LADSPA_Data) biquad_run(filter, input[pos]));
+    }
 }
 
 void _init(void);
@@ -71,53 +152,97 @@ void _init(void) {
     LADSPA_PortDescriptor *port_descriptors;
     LADSPA_PortRangeHint *port_range_hints;
 
-    linkwitzDescriptor = (LADSPA_Descriptor *)malloc(sizeof(LADSPA_Descriptor));
+#define D_(s) (s)
+
+    linkwitzDescriptor =
+     (LADSPA_Descriptor *)malloc(sizeof(LADSPA_Descriptor));
 
     if (linkwitzDescriptor) {
         linkwitzDescriptor->UniqueID = 9003;
         linkwitzDescriptor->Label = "RTlinkwitzeq";
-        linkwitzDescriptor->Properties = LADSPA_PROPERTY_HARD_RT_CAPABLE;
-        linkwitzDescriptor->Name = "RT Linkwitz Equalizer";
-        linkwitzDescriptor->Maker = "Stefan Janhunen <sjanhunen@gmail.com>";
-        linkwitzDescriptor->Copyright = "GPL";
-        linkwitzDescriptor->PortCount = 4;
+        linkwitzDescriptor->Properties =
+         LADSPA_PROPERTY_HARD_RT_CAPABLE;
+        linkwitzDescriptor->Name =
+         D_("RT Linkwitz Transform Equalizer");
+        linkwitzDescriptor->Maker =
+         "Stefan Janhunen <sjanhunen@gmail.com>";
+        linkwitzDescriptor->Copyright =
+         "GPL";
+        linkwitzDescriptor->PortCount = 6;
 
-        port_descriptors = (LADSPA_PortDescriptor *)calloc(4, sizeof(LADSPA_PortDescriptor));
-        linkwitzDescriptor->PortDescriptors = (const LADSPA_PortDescriptor *)port_descriptors;
+        port_descriptors = (LADSPA_PortDescriptor *)calloc(6,
+         sizeof(LADSPA_PortDescriptor));
+        linkwitzDescriptor->PortDescriptors =
+         (const LADSPA_PortDescriptor *)port_descriptors;
 
-        port_range_hints = (LADSPA_PortRangeHint *)calloc(4, sizeof(LADSPA_PortRangeHint));
-        linkwitzDescriptor->PortRangeHints = (const LADSPA_PortRangeHint *)port_range_hints;
+        port_range_hints = (LADSPA_PortRangeHint *)calloc(6,
+         sizeof(LADSPA_PortRangeHint));
+        linkwitzDescriptor->PortRangeHints =
+         (const LADSPA_PortRangeHint *)port_range_hints;
 
-        port_names = (char **)calloc(4, sizeof(char*));
-        linkwitzDescriptor->PortNames = (const char **)port_names;
+        port_names = (char **)calloc(6, sizeof(char*));
+        linkwitzDescriptor->PortNames =
+         (const char **)port_names;
 
-        // Parameters for f0
-        port_descriptors[LINKWITZ_F0] = LADSPA_PORT_INPUT | LADSPA_PORT_CONTROL;
-        port_names[LINKWITZ_F0] = "f0 - Natural resonant frequency of the driver in a sealed box";
-        port_range_hints[LINKWITZ_F0].HintDescriptor = LADSPA_HINT_BOUNDED_BELOW | LADSPA_HINT_BOUNDED_ABOVE;
-        port_range_hints[LINKWITZ_F0].LowerBound = 0.0F;
-        port_range_hints[LINKWITZ_F0].UpperBound = 20000.0F;
+        /* Parameters for f0 */
+        port_descriptors[LINKWITZ_F0] =
+         LADSPA_PORT_INPUT | LADSPA_PORT_CONTROL;
+        port_names[LINKWITZ_F0] =
+         D_("f0 - Natural resonant frequency (Hz)");
+        port_range_hints[LINKWITZ_F0].HintDescriptor =
+         LADSPA_HINT_BOUNDED_BELOW | LADSPA_HINT_BOUNDED_ABOVE | LADSPA_HINT_DEFAULT_440;
+        port_range_hints[LINKWITZ_F0].LowerBound = 1.0f;
+        port_range_hints[LINKWITZ_F0].UpperBound = 20000.0f;
 
-        // Parameters for Q0
-        port_descriptors[LINKWITZ_Q0] = LADSPA_PORT_INPUT | LADSPA_PORT_CONTROL;
-        port_names[LINKWITZ_Q0] = "Q0 - Natural Q factor of the driver in a sealed box";
-        port_range_hints[LINKWITZ_Q0].HintDescriptor = LADSPA_HINT_BOUNDED_BELOW | LADSPA_HINT_BOUNDED_ABOVE;
-        port_range_hints[LINKWITZ_Q0].LowerBound = 0.1F;
-        port_range_hints[LINKWITZ_Q0].UpperBound = 10.0F;
+        /* Parameters for Q0 */
+        port_descriptors[LINKWITZ_Q0] =
+         LADSPA_PORT_INPUT | LADSPA_PORT_CONTROL;
+        port_names[LINKWITZ_Q0] =
+         D_("Q0 - Natural Q factor");
+        port_range_hints[LINKWITZ_Q0].HintDescriptor =
+         LADSPA_HINT_BOUNDED_BELOW | LADSPA_HINT_BOUNDED_ABOVE | LADSPA_HINT_DEFAULT_1;
+        port_range_hints[LINKWITZ_Q0].LowerBound = 0.1f;
+        port_range_hints[LINKWITZ_Q0].UpperBound = 10.0f;
 
-        // Parameters for fp
-        port_descriptors[LINKWITZ_FP] = LADSPA_PORT_INPUT | LADSPA_PORT_CONTROL;
-        port_names[LINKWITZ_FP] = "fp - Equalized resonant frequency of the driver in a sealed box";
-        port_range_hints[LINKWITZ_FP].HintDescriptor = LADSPA_HINT_BOUNDED_BELOW | LADSPA_HINT_BOUNDED_ABOVE;
-        port_range_hints[LINKWITZ_FP].LowerBound = 0.0F;
-        port_range_hints[LINKWITZ_FP].UpperBound = 20000.0F;
+        /* Parameters for fp */
+        port_descriptors[LINKWITZ_FP] =
+         LADSPA_PORT_INPUT | LADSPA_PORT_CONTROL;
+        port_names[LINKWITZ_FP] =
+         D_("fp - Target resonant frequency (Hz)");
+        port_range_hints[LINKWITZ_FP].HintDescriptor =
+         LADSPA_HINT_BOUNDED_BELOW | LADSPA_HINT_BOUNDED_ABOVE | LADSPA_HINT_DEFAULT_440;
+        port_range_hints[LINKWITZ_FP].LowerBound = 1.0f;
+        port_range_hints[LINKWITZ_FP].UpperBound = 20000.0f;
 
-        // Parameters for Qp
-        port_descriptors[LINKWITZ_QP] = LADSPA_PORT_INPUT | LADSPA_PORT_CONTROL;
-        port_names[LINKWITZ_QP] = "Qp - Equalized Q factor of the driver in a sealed box";
-        port_range_hints[LINKWITZ_QP].HintDescriptor = LADSPA_HINT_BOUNDED_BELOW | LADSPA_HINT_BOUNDED_ABOVE;
-        port_range_hints[LINKWITZ_QP].LowerBound = 0.1F;
-        port_range_hints[LINKWITZ_QP].UpperBound = 10.0F;
+        /* Parameters for Qp */
+        port_descriptors[LINKWITZ_QP] =
+         LADSPA_PORT_INPUT | LADSPA_PORT_CONTROL;
+        port_names[LINKWITZ_QP] =
+         D_("Qp - Target Q factor");
+        port_range_hints[LINKWITZ_QP].HintDescriptor =
+         LADSPA_HINT_BOUNDED_BELOW | LADSPA_HINT_BOUNDED_ABOVE | LADSPA_HINT_DEFAULT_1;
+        port_range_hints[LINKWITZ_QP].LowerBound = 0.1f;
+        port_range_hints[LINKWITZ_QP].UpperBound = 10.0f;
+
+        /* Parameters for Input */
+        port_descriptors[LINKWITZ_INPUT] =
+         LADSPA_PORT_INPUT | LADSPA_PORT_AUDIO;
+        port_names[LINKWITZ_INPUT] =
+         D_("Input");
+        port_range_hints[LINKWITZ_INPUT].HintDescriptor =
+         LADSPA_HINT_BOUNDED_BELOW | LADSPA_HINT_BOUNDED_ABOVE;
+        port_range_hints[LINKWITZ_INPUT].LowerBound = -1.0f;
+        port_range_hints[LINKWITZ_INPUT].UpperBound = +1.0f;
+
+        /* Parameters for Output */
+        port_descriptors[LINKWITZ_OUTPUT] =
+         LADSPA_PORT_OUTPUT | LADSPA_PORT_AUDIO;
+        port_names[LINKWITZ_OUTPUT] =
+         D_("Output");
+        port_range_hints[LINKWITZ_OUTPUT].HintDescriptor =
+         LADSPA_HINT_BOUNDED_BELOW | LADSPA_HINT_BOUNDED_ABOVE;
+        port_range_hints[LINKWITZ_OUTPUT].LowerBound = -1.0f;
+        port_range_hints[LINKWITZ_OUTPUT].UpperBound = +1.0f;
 
         linkwitzDescriptor->activate = activateLinkwitz;
         linkwitzDescriptor->cleanup = cleanupLinkwitz;

--- a/testing/ladspa_testing.R
+++ b/testing/ladspa_testing.R
@@ -110,4 +110,5 @@ makegraph( "RTlr4lowpass,500", 500, -6, xlim=c(20,3000) );
 makegraph( "RTlr4hipass,500", 500, -6, xlim=c(100,20000) );
 makegraph( "RTallpass1,500", 500, 0, ylim=c(-3,3) );
 makegraph( "RTallpass2,500,0.7", 500, 0, ylim=c(-3,3) );
+makegraph( "RTlinkwitzeq,100,1,50,0.5", 500, 0, ylim=c(-3,3) );
 

--- a/testing/ladspa_testing.R
+++ b/testing/ladspa_testing.R
@@ -77,10 +77,8 @@ makegraph <- function(filter,reffreq,reflevel,xlim=c(20,20000),ylim=c(-20,5)) {
 
   # plot magnitude response ========================================================
 	x11(width=6,height=4);
-	plot( f, 20*log10(Y1), type="l", log="x", col="blue", lwd=2, xlim=xlim, ylim=ylim, yaxt="n",
+	plot( f, 20*log10(Y1), type="l", log="x", col="blue", lwd=2, xlim=xlim, ylim=ylim,
 		    xlab="frequency [Hz]", ylab="level [dB]", main=sprintf("Magnitude Response\n %s",filter) );
-  axis(2, at=3*(-6:1));
-  axis(4, at=3*(-6:1));
 
 	abline( v=reffreq, col="grey" );
 	abline( h=c(0,reflevel), col="grey" );

--- a/testing/ladspa_testing.R
+++ b/testing/ladspa_testing.R
@@ -110,5 +110,4 @@ makegraph( "RTlr4lowpass,500", 500, -6, xlim=c(20,3000) );
 makegraph( "RTlr4hipass,500", 500, -6, xlim=c(100,20000) );
 makegraph( "RTallpass1,500", 500, 0, ylim=c(-3,3) );
 makegraph( "RTallpass2,500,0.7", 500, 0, ylim=c(-3,3) );
-makegraph( "RTlinkwitzeq,100,1,50,0.5", 500, 0, ylim=c(-3,3) );
-
+makegraph( "RTlinkwitzeq,119,1.23,60,0.7", 500, 0, ylim=c(-6,20) );

--- a/testing/linkwitz.c
+++ b/testing/linkwitz.c
@@ -1,0 +1,39 @@
+#include "R.h"
+#include <math.h>
+
+void calculate_linkwitz_biquad(
+        double *a, double *b,
+        double f0, double q0,
+        double fp, double qp,
+        double fs) {
+
+    // Analog domain coefficients
+    double d0i = pow((2*PI*f0), 2);
+    double d1i = (2*PI*f0)/q0;
+    double d2i = 1;
+
+    double c0i = pow((2*PI*fp), 2);
+    double c1i = (2*PI*fp)/qp;
+    double c2i = 1;
+
+    double fc = (f0 + fp) / 2;
+    double gn = (2*PI*fc)/(tan(PI*fc/fs));
+    double cci = c0i+gn*c1i+gn*gn*c2i;
+
+    // Digital domain coefficients
+    a[0] = 1;
+    a[1] = (2*(c0i-(gn*gn)*c2i)/cci);
+    a[2] = ((c0i-gn*c1i+(gn*gn)*c2i)/cci);
+
+    b[0] = (d0i+gn*d1i+(gn*gn)*d2i)/cci;
+    b[1] = 2*(d0i-(gn*gn)*d2i)/cci;
+    b[2] = (d0i-gn*d1i+(gn*gn)*d2i)/cci;
+}
+
+void calculate_linkwitz_biquad_wrapper(
+        double *a, double *b,
+        double *f0, double *q0,
+        double *fp, double *qp,
+        double *fs) {
+    calculate_linkwitz_biquad(a, b, *f0, *q0, *fp, *qp, *fs);
+}

--- a/testing/linkwitz.c
+++ b/testing/linkwitz.c
@@ -1,34 +1,5 @@
 #include "R.h"
-#include <math.h>
-
-void calculate_linkwitz_biquad(
-        double *a, double *b,
-        double f0, double q0,
-        double fp, double qp,
-        double fs) {
-
-    // Analog domain coefficients
-    double d0i = pow((2*PI*f0), 2);
-    double d1i = (2*PI*f0)/q0;
-    double d2i = 1;
-
-    double c0i = pow((2*PI*fp), 2);
-    double c1i = (2*PI*fp)/qp;
-    double c2i = 1;
-
-    double fc = (f0 + fp) / 2;
-    double gn = (2*PI*fc)/(tan(PI*fc/fs));
-    double cci = c0i+gn*c1i+gn*gn*c2i;
-
-    // Digital domain coefficients
-    a[0] = 1;
-    a[1] = (2*(c0i-(gn*gn)*c2i)/cci);
-    a[2] = ((c0i-gn*c1i+(gn*gn)*c2i)/cci);
-
-    b[0] = (d0i+gn*d1i+(gn*gn)*d2i)/cci;
-    b[1] = 2*(d0i-(gn*gn)*d2i)/cci;
-    b[2] = (d0i-gn*d1i+(gn*gn)*d2i)/cci;
-}
+#include "../include/linkwitz.h"
 
 void calculate_linkwitz_biquad_wrapper(
         double *a, double *b,

--- a/testing/linkwitz_transform.R
+++ b/testing/linkwitz_transform.R
@@ -28,8 +28,8 @@ linkwitz_transform_biquad <- function(f0, q0, fp, qp, fs) {
 
   # Digital domain coefficients
   a0 = 1
-  a1 = -(2*(c0i-(gn^2)*c2i)/cci)
-  a2 = -((c0i-gn*c1i+(gn^2)*c2i)/cci)
+  a1 = (2*(c0i-(gn^2)*c2i)/cci)
+  a2 = ((c0i-gn*c1i+(gn^2)*c2i)/cci)
 
   b0 = (d0i+gn*d1i+(gn^2)*d2i)/cci
   b1 = 2*(d0i-(gn^2)*d2i)/cci
@@ -46,8 +46,7 @@ calculate_frequency_response <- function(b0, b1, b2, a0, a1, a2, fs, num_points 
   z <- exp(1i * w)
   z_inv <- 1/z
 
-  # TODO: need to decide how to best represent coefficients
-  H <- (b0 + b1 * z_inv + b2 * z_inv^2) / (a0 - a1 * z_inv - a2 * z_inv^2)
+  H <- (b0 + b1 * z_inv + b2 * z_inv^2) / (a0 + a1 * z_inv + a2 * z_inv^2)
   magnitude_db <- 20 * log10(abs(H))
   phase <- atan2(Im(H), Re(H))
   

--- a/testing/linkwitz_transform.R
+++ b/testing/linkwitz_transform.R
@@ -1,0 +1,79 @@
+# Calculate Linkwitz Transform Biquad Coefficients
+#'
+#' This function calculates the biquad filter coefficients for a Linkwitz transform.
+#' It transforms the response of a sealed box speaker to match that of another
+#' sealed box speaker with different parameters, typically with a lower F0.
+#'
+#' @param f0 Original resonance frequency of the sealed box speaker
+#' @param q0 Original Q factor of the sealed box speaker
+#' @param fp Desired (new) resonance frequency after transformation
+#' @param qp Desired (new) Q factor after transformation
+#' @param fs Sampling frequency
+#'
+#' @return A list containing the biquad filter coefficients (b0, b1, b2, a0, a1, a2)
+#'
+linkwitz_transform_biquad <- function(f0, q0, fp, qp, fs) {
+  # Analog domain coefficients
+  d0i = (2*pi*f0)^2
+  d1i = (2*pi*f0)/q0 
+  d2i = 1
+
+  c0i = (2*pi*fp)^2
+  c1i = (2*pi*fp)/qp
+  c2i = 1
+
+  fc = (f0 + fp) / 2
+  gn = (2*pi*fc)/(tan(pi*fc/fs))
+  cci = c0i+gn*c1i+gn*gn*c2i
+
+  # Digital domain coefficients
+  a0 = 1
+  a1 = -(2*(c0i-(gn^2)*c2i)/cci)
+  a2 = -((c0i-gn*c1i+(gn^2)*c2i)/cci)
+
+  b0 = (d0i+gn*d1i+(gn^2)*d2i)/cci
+  b1 = 2*(d0i-(gn^2)*d2i)/cci
+  b2 = (d0i-gn*d1i+(gn^2)*d2i)/cci
+  
+  # Return coefficients as a list
+  return(list(b0 = b0, b1 = b1, b2 = b2, a0 = 1, a1 = a1, a2 = a2))
+}
+
+# Calculate frequency response of biquad filter
+calculate_frequency_response <- function(b0, b1, b2, a0, a1, a2, fs, num_points = 1000) {
+  f <- seq(10, 1000, length.out = num_points)
+  w <- 2 * pi * f / fs
+  z <- exp(1i * w)
+  z_inv <- 1/z
+
+  # TODO: need to decide how to best represent coefficients
+  H <- (b0 + b1 * z_inv + b2 * z_inv^2) / (a0 - a1 * z_inv - a2 * z_inv^2)
+  magnitude_db <- 20 * log10(abs(H))
+  phase <- atan2(Im(H), Re(H))
+  
+  return(list(f = f, magnitude_db = magnitude_db, phase = phase))
+}
+
+# Plot frequency response
+plot_frequency_response <- function(coeffs, fs, title = "Biquad Filter Frequency Response") {
+  response <- calculate_frequency_response(coeffs$b0, coeffs$b1, coeffs$b2, 
+                                           coeffs$a0, coeffs$a1, coeffs$a2, fs)
+  
+  par(mfrow = c(2, 1))
+  
+  # Magnitude plot
+  plot(response$f, response$magnitude_db, type = "l", col = "blue",
+       xlab = "Frequency (Hz)", ylab = "Magnitude (dB)",
+       main = title)
+  grid()
+
+  # Phase plot
+  plot(response$f, response$phase * 180 / pi, type = "l", col = "red",
+       xlab = "Frequency (Hz)", ylab = "Phase (degrees)",
+       main = "Phase Response")
+  grid()
+}
+
+coeffs <- linkwitz_transform_biquad(f0 = 119, q0 = 1.23, fp = 60, qp = 0.7, fs = 48000)
+plot_frequency_response(coeffs, fs = 48000, title = "Linkwitz Transform Frequency Response")
+print(coeffs)

--- a/testing/linkwitz_transform.R
+++ b/testing/linkwitz_transform.R
@@ -1,3 +1,5 @@
+dyn.load("./linkwitz.so");
+
 # Calculate Linkwitz Transform Biquad Coefficients
 #'
 #' This function calculates the biquad filter coefficients for a Linkwitz transform.
@@ -39,6 +41,26 @@ linkwitz_transform_biquad <- function(f0, q0, fp, qp, fs) {
   return(list(b0 = b0, b1 = b1, b2 = b2, a0 = 1, a1 = a1, a2 = a2))
 }
 
+calculate_linkwitz_biquad <- function(f0, q0, fp, qp, fs) {
+    res = .C( "calculate_linkwitz_biquad_wrapper",
+            a=double(3),
+            b=double(3),
+            as.double(f0),
+            as.double(q0),
+            as.double(fp),
+            as.double(qp),
+            as.double(fs)
+    )
+
+    return(list(
+                b0=res$b[[1]],
+                b1=res$b[[2]],
+                b2=res$b[[3]],
+                a0=res$a[[1]],
+                a1=res$a[[2]],
+                a2=res$a[[3]]))
+}
+
 # Calculate frequency response of biquad filter
 calculate_frequency_response <- function(b0, b1, b2, a0, a1, a2, fs, num_points = 1000) {
   f <- seq(10, 1000, length.out = num_points)
@@ -73,6 +95,10 @@ plot_frequency_response <- function(coeffs, fs, title = "Biquad Filter Frequency
   grid()
 }
 
-coeffs <- linkwitz_transform_biquad(f0 = 119, q0 = 1.23, fp = 60, qp = 0.7, fs = 48000)
-plot_frequency_response(coeffs, fs = 48000, title = "Linkwitz Transform Frequency Response")
-print(coeffs)
+coeffs1 <- linkwitz_transform_biquad(f0 = 119, q0 = 1.23, fp = 60, qp = 0.7, fs = 48000)
+print(coeffs1)
+
+coeffs2 <- calculate_linkwitz_biquad(f0 = 119, q0 = 1.23, fp = 60, qp = 0.7, fs = 48000)
+print(coeffs2)
+
+plot_frequency_response(coeffs2, fs = 48000, title = "Linkwitz Transform Frequency Response")

--- a/testing/linkwitz_transform.R
+++ b/testing/linkwitz_transform.R
@@ -14,7 +14,7 @@ dyn.load("./linkwitz.so");
 #'
 #' @return A list containing the biquad filter coefficients (b0, b1, b2, a0, a1, a2)
 #'
-linkwitz_transform_biquad <- function(f0, q0, fp, qp, fs) {
+calc_ref_linkwitz_coeffs <- function(f0, q0, fp, qp, fs) {
   # Analog domain coefficients
   d0i = (2*pi*f0)^2
   d1i = (2*pi*f0)/q0 
@@ -41,7 +41,7 @@ linkwitz_transform_biquad <- function(f0, q0, fp, qp, fs) {
   return(list(b0 = b0, b1 = b1, b2 = b2, a0 = 1, a1 = a1, a2 = a2))
 }
 
-calculate_linkwitz_biquad <- function(f0, q0, fp, qp, fs) {
+calc_rt_linkwitz_coeffs <- function(f0, q0, fp, qp, fs) {
     res = .C( "calculate_linkwitz_biquad_wrapper",
             a=double(3),
             b=double(3),
@@ -95,22 +95,19 @@ plot_frequency_response <- function(coeffs, fs, title = "Biquad Filter Frequency
   grid()
 }
 
-coeffs1 <- linkwitz_transform_biquad(f0 = 119, q0 = 1.23, fp = 60, qp = 0.7, fs = 44100)
-coeffs2 <- calculate_linkwitz_biquad(f0 = 119, q0 = 1.23, fp = 60, qp = 0.7, fs = 44100)
+coeffs1 <- calc_ref_linkwitz_coeffs(f0 = 119, q0 = 1.23, fp = 60, qp = 0.7, fs = 44100)
+coeffs2 <- calc_rt_linkwitz_coeffs(f0 = 119, q0 = 1.23, fp = 60, qp = 0.7, fs = 44100)
 
 # Check if coefficients match within tolerance
 tolerance <- 1e-10
 coeff_diffs <- mapply('-', coeffs1, coeffs2)
 coeff_diffs_abs <- abs(coeff_diffs)
 
-print("Comparing coefficients between implementations:")
 if(any(coeff_diffs_abs > tolerance)) {
   print("WARNING: Implementations differ beyond tolerance!")
   # Print which coefficients exceeded tolerance
   failing_coeffs <- names(coeff_diffs)[coeff_diffs_abs > tolerance]
   print(paste("Coefficients exceeding tolerance:", paste(failing_coeffs, collapse=", ")))
-} else {
-  print("SUCCESS: Implementations match within tolerance")
 }
 
 plot_frequency_response(coeffs2, fs = 48000, title = "Linkwitz Transform Frequency Response")

--- a/testing/linkwitz_transform.R
+++ b/testing/linkwitz_transform.R
@@ -96,9 +96,21 @@ plot_frequency_response <- function(coeffs, fs, title = "Biquad Filter Frequency
 }
 
 coeffs1 <- linkwitz_transform_biquad(f0 = 119, q0 = 1.23, fp = 60, qp = 0.7, fs = 48000)
-print(coeffs1)
-
 coeffs2 <- calculate_linkwitz_biquad(f0 = 119, q0 = 1.23, fp = 60, qp = 0.7, fs = 48000)
-print(coeffs2)
+
+# Check if coefficients match within tolerance
+tolerance <- 1e-10
+coeff_diffs <- mapply('-', coeffs1, coeffs2)
+coeff_diffs_abs <- abs(coeff_diffs)
+
+print("Comparing coefficients between implementations:")
+if(any(coeff_diffs_abs > tolerance)) {
+  print("WARNING: Implementations differ beyond tolerance!")
+  # Print which coefficients exceeded tolerance
+  failing_coeffs <- names(coeff_diffs)[coeff_diffs_abs > tolerance]
+  print(paste("Coefficients exceeding tolerance:", paste(failing_coeffs, collapse=", ")))
+} else {
+  print("SUCCESS: Implementations match within tolerance")
+}
 
 plot_frequency_response(coeffs2, fs = 48000, title = "Linkwitz Transform Frequency Response")

--- a/testing/linkwitz_transform.R
+++ b/testing/linkwitz_transform.R
@@ -95,8 +95,8 @@ plot_frequency_response <- function(coeffs, fs, title = "Biquad Filter Frequency
   grid()
 }
 
-coeffs1 <- linkwitz_transform_biquad(f0 = 119, q0 = 1.23, fp = 60, qp = 0.7, fs = 48000)
-coeffs2 <- calculate_linkwitz_biquad(f0 = 119, q0 = 1.23, fp = 60, qp = 0.7, fs = 48000)
+coeffs1 <- linkwitz_transform_biquad(f0 = 119, q0 = 1.23, fp = 60, qp = 0.7, fs = 44100)
+coeffs2 <- calculate_linkwitz_biquad(f0 = 119, q0 = 1.23, fp = 60, qp = 0.7, fs = 44100)
 
 # Check if coefficients match within tolerance
 tolerance <- 1e-10


### PR DESCRIPTION
Complete implementation and test cases for `RTlinkwitzeq`:
* Add both R and C implementations for calculation of Linkwitz Transform coefficients
* Implement `RTlinkwitzeq` as LADSPA plugin
* Add new test bench for Linkwitz Transform coefficients
* Plot plugin output with `ladspa_testing.R`

Resolves #8